### PR TITLE
修复Token时间不正常

### DIFF
--- a/components/src/main/java/com/chuanglian/mingpin/utils/JwtUtil.java
+++ b/components/src/main/java/com/chuanglian/mingpin/utils/JwtUtil.java
@@ -18,7 +18,7 @@ public class JwtUtil {
         // 生成JWT
         return JWT.create()
                 .withClaim("user", claims) // 添加载荷
-                .withExpiresAt(new Date(System.currentTimeMillis() + 1000 * 60 * 60 * 24 * 30)) // 过期时间2小时
+                .withExpiresAt(new Date(System.currentTimeMillis() + 1000L * 60 * 60 * 24 * 30)) // 过期时间2小时
                 .sign(Algorithm.HMAC256("com/chuanglian/mingpin")); // 设置密钥
     }
 


### PR DESCRIPTION
# 修复Token时间不正常

1. 解决了长期Token时间溢出的问题（显示为8月17日过期）。
2. 恢复了用于测试的长期Token使用。