### PR TITLE
修改了Campus模块的VO类命名

### DIFF
--- a/campus-management/src/main/java/com/chuanglian/mingpin/controller/TeacherController.java
+++ b/campus-management/src/main/java/com/chuanglian/mingpin/controller/TeacherController.java
@@ -1,6 +1,6 @@
 package com.chuanglian.mingpin.controller;
 
-import com.chuanglian.mingpin.pojo.TeacherVO;
+import com.chuanglian.mingpin.pojo.CampusTeacherVO;
 import com.chuanglian.mingpin.pojo.Result;
 import com.chuanglian.mingpin.pojo.TeacherVoForUpdate;
 import com.chuanglian.mingpin.service.TeacherService;
@@ -30,14 +30,14 @@ public class TeacherController {
 
     /**
      * 新增教师
-     * @param teacherVO
+     * @param campusTeacherVO
      * @return
      * @throws IOException
      */
     @PostMapping("/addTeacher")
-    public Result add( @ModelAttribute TeacherVO teacherVO) throws IOException {
-        log.info("新增教师: {}" , teacherVO);
-        return teacherService.add(teacherVO);
+    public Result add( @ModelAttribute CampusTeacherVO campusTeacherVO) throws IOException {
+        log.info("新增教师: {}" , campusTeacherVO);
+        return teacherService.add(campusTeacherVO);
     }
 
     /**

--- a/campus-management/src/main/java/com/chuanglian/mingpin/pojo/CampusTeacherVO.java
+++ b/campus-management/src/main/java/com/chuanglian/mingpin/pojo/CampusTeacherVO.java
@@ -9,7 +9,7 @@ import java.time.LocalDateTime;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-public class TeacherVO {
+public class CampusTeacherVO {
     @JsonProperty("avatarAddress")
     private String avatar;
     private String sex;  //男 ？ 女

--- a/campus-management/src/main/java/com/chuanglian/mingpin/service/TeacherService.java
+++ b/campus-management/src/main/java/com/chuanglian/mingpin/service/TeacherService.java
@@ -6,7 +6,7 @@ import com.chuanglian.mingpin.pojo.*;
 import java.util.List;
 
 public interface TeacherService {
-    Result add(TeacherVO teacher) ;
+    Result add(CampusTeacherVO teacher) ;
 
     List<TeacherVoForShow> getAllTeacherUsers();
 

--- a/campus-management/src/main/java/com/chuanglian/mingpin/service/impl/TeacherServiceImpl.java
+++ b/campus-management/src/main/java/com/chuanglian/mingpin/service/impl/TeacherServiceImpl.java
@@ -8,7 +8,6 @@ import com.chuanglian.mingpin.pojo.*;
 import com.chuanglian.mingpin.mapper.user.TeacherMapper;
 import com.chuanglian.mingpin.service.TeacherService;
 import org.springframework.beans.BeanUtils;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -38,11 +37,11 @@ public class TeacherServiceImpl implements TeacherService {
 
     @Override
     @Transactional
-    public Result add(TeacherVO teacherVo) {
+    public Result add(CampusTeacherVO campusTeacherVo) {
         Teacher teacher = new Teacher();
         User user = new User();
-        BeanUtils.copyProperties(teacherVo, teacher);
-        BeanUtils.copyProperties(teacherVo, user);
+        BeanUtils.copyProperties(campusTeacherVo, teacher);
+        BeanUtils.copyProperties(campusTeacherVo, user);
         user.setPassword(passwordEncoder.encode(user.getPassword()));
         teacher.setCreatedAt(LocalDateTime.now());
         teacher.setUpdatedAt(LocalDateTime.now());


### PR DESCRIPTION
修改了Campus模块的VO类命名

1. 将Campus模块的TeacherVO类改名为CampusTeacherVO，来防止类名重复。